### PR TITLE
Add support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "require": {
         "php": ">=7.2|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "ext-curl": "*",
         "ext-json": "*"
     },


### PR DESCRIPTION
This change adds support for Laravel 9.x by allowing the `^9.0|^10.0` versions of `illuminate/support`.